### PR TITLE
Fix bitrate string comparison

### DIFF
--- a/converter/converter.go
+++ b/converter/converter.go
@@ -264,7 +264,7 @@ func (c *Converter) extendCoverArgs() error {
 }
 
 func (c *Converter) extendBitRateArgs() {
-	if c.bitRate != "" {
+	if c.bitRate != 0 {
 		c.extendCmdArgs("-b:a", fmt.Sprintf("%d", c.bitRate))
 	}
 }


### PR DESCRIPTION
This was causing compilation issues since the `bitrate` was changed from a `string` to an `int`.