### PR TITLE
Add Windows compatibility

### DIFF
--- a/converter/utils.go
+++ b/converter/utils.go
@@ -15,7 +15,7 @@ func GetEncoderName() string {
 }
 
 func IsCommandAvailable(name string) bool {
-	cmd := exec.Command("which", name)
+	cmd := exec.Command("where", name)
 	if err := cmd.Run(); err != nil {
 		return false
 	}

--- a/converter/utils.go
+++ b/converter/utils.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"fmt"
+	"runtime"
 
 	"os/exec"
 )
@@ -15,9 +16,21 @@ func GetEncoderName() string {
 }
 
 func IsCommandAvailable(name string) bool {
-	cmd := exec.Command("where", name)
+	cmd := exec.Command(getCheckCommand(), name)
 	if err := cmd.Run(); err != nil {
 		return false
 	}
 	return true
+}
+
+func getOS() string {
+	return runtime.GOOS
+}
+
+func getCheckCommand() string {
+	if getOS() == "windows" {
+		return "where"
+	} else {
+		return "which"
+	}
 }


### PR DESCRIPTION
This is a fix to the original package not working in Windows OS. 

While using the converter package in Windows, it returns an error with the message `command "ffmpeg" not found`. This happens despite ffmpeg being installed and accessible from Windows CMD. The problem lies in the implementation of `IsCommandAvailable` function in `converter/utils.go`, where it uses the "which" command to check if encoder is installed. Since "which" command is not available in Windows, the function always returns false. 

The fix is to replace "which" with "where" in Windows runtime.  